### PR TITLE
fix: update arithmetic operations in shader files for Android compatibility

### DIFF
--- a/assets/shaders/cine_negative.fs
+++ b/assets/shaders/cine_negative.fs
@@ -117,9 +117,9 @@ vec4 shine_effect( vec4 colour, vec4 tex, vec2 uv, vec2 texture_coords ){
     tex.b = tex.b-delta + delta*maxfac*0.7 - 0.1;
     tex.a = tex.a*(0.5*max(min(1., max(0.,0.3*max(low*0.2, delta)+ min(max(maxfac*0.1,0.), 0.4)) ), 0.) + 0.15*maxfac*(0.1+delta));
 
-    tex.r = orig_rgba.r * (1 - tex.a) + tex.r * tex.a;
-    tex.g = orig_rgba.g * (1 - tex.a) + tex.g * tex.a;
-    tex.b = orig_rgba.b * (1 - tex.a) + tex.b * tex.a;
+    tex.r = orig_rgba.r * (1. - tex.a) + tex.r * tex.a;
+    tex.g = orig_rgba.g * (1. - tex.a) + tex.g * tex.a;
+    tex.b = orig_rgba.b * (1. - tex.a) + tex.b * tex.a;
     tex.a = orig_rgba.a;
 
     return dissolve_mask(tex*colour, texture_coords, uv);
@@ -133,9 +133,9 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
     float omit_top_half = cine_negative[2];
     float omit_bottom_half = cine_negative[3];
 
-    if (uv.y <= 0.375 && omit_top_half > 0){
+    if (uv.y <= 0.375 && omit_top_half > 0.){
         tex.a = 0.;
-    } else if (uv.y > 0.375 && omit_bottom_half > 0) {
+    } else if (uv.y > 0.375 && omit_bottom_half > 0.) {
         tex.a = 0.;
     }
 
@@ -153,9 +153,9 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
 	if (tex[3] < 0.7)
 		tex[3] = tex[3]/3.;
 
-    tex.r = orig_rgba.r * (1 - tex.a) + tex.r * tex.a;
-    tex.g = orig_rgba.g * (1 - tex.a) + tex.g * tex.a;
-    tex.b = orig_rgba.b * (1 - tex.a) + tex.b * tex.a;
+    tex.r = orig_rgba.r * (1. - tex.a) + tex.r * tex.a;
+    tex.g = orig_rgba.g * (1. - tex.a) + tex.g * tex.a;
+    tex.b = orig_rgba.b * (1. - tex.a) + tex.b * tex.a;
     tex.a = orig_rgba.a;
 
 	return shine_effect(colour, tex, uv, texture_coords);

--- a/assets/shaders/cine_polychrome.fs
+++ b/assets/shaders/cine_polychrome.fs
@@ -117,9 +117,9 @@ vec4 shine_effect( vec4 colour, vec4 tex, vec2 uv, vec2 texture_coords ){
     tex.b = tex.b-delta + delta*maxfac*0.7 - 0.1;
     tex.a = tex.a*(0.5*max(min(1., max(0.,0.3*max(low*0.2, delta)+ min(max(maxfac*0.1,0.), 0.4)) ), 0.) + 0.15*maxfac*(0.1+delta));
 
-    tex.r = orig_rgba.r * (1 - tex.a) + tex.r * tex.a;
-    tex.g = orig_rgba.g * (1 - tex.a) + tex.g * tex.a;
-    tex.b = orig_rgba.b * (1 - tex.a) + tex.b * tex.a;
+    tex.r = orig_rgba.r * (1. - tex.a) + tex.r * tex.a;
+    tex.g = orig_rgba.g * (1. - tex.a) + tex.g * tex.a;
+    tex.b = orig_rgba.b * (1. - tex.a) + tex.b * tex.a;
     tex.a = orig_rgba.a;
 
     return dissolve_mask(tex*colour, texture_coords, uv);
@@ -133,9 +133,9 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
     float omit_top_half = cine_polychrome[2];
     float omit_bottom_half = cine_polychrome[3];
 
-    if (uv.y <= 0.375 && omit_top_half > 0){
+    if (uv.y <= 0.375 && omit_top_half > 0.){
         tex.a = 0.;
-    } else if (uv.y > 0.375 && omit_bottom_half > 0) {
+    } else if (uv.y > 0.375 && omit_bottom_half > 0.) {
         tex.a = 0.;
     }
 
@@ -170,9 +170,9 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
 	if (tex[3] < 0.7)
 		tex[3] = tex[3]/3.;
 
-    tex.r = orig_rgba.r * (1 - tex.a) + tex.r * tex.a;
-    tex.g = orig_rgba.g * (1 - tex.a) + tex.g * tex.a;
-    tex.b = orig_rgba.b * (1 - tex.a) + tex.b * tex.a;
+    tex.r = orig_rgba.r * (1. - tex.a) + tex.r * tex.a;
+    tex.g = orig_rgba.g * (1. - tex.a) + tex.g * tex.a;
+    tex.b = orig_rgba.b * (1. - tex.a) + tex.b * tex.a;
     tex.a = orig_rgba.a;
 
 	return shine_effect(colour, tex, uv, texture_coords);

--- a/assets/shaders/ticket.fs
+++ b/assets/shaders/ticket.fs
@@ -59,9 +59,9 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
     float omit_top_half = ticket[2];
     float omit_bottom_half = ticket[3];
 
-    if (uv.y <= 0.375 && omit_top_half > 0){
+    if (uv.y <= 0.375 && omit_top_half > 0.){
         tex.a = 0.;
-    } else if (uv.y > 0.375 && omit_bottom_half > 0) {
+    } else if (uv.y > 0.375 && omit_bottom_half > 0.) {
         tex.a = 0.;
     }
 
@@ -97,9 +97,9 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
 
         tex.a *= 0.6;
 
-        tex.r = orig_rgba.r * (1 - tex.a) + tex.r * tex.a;
-        tex.g = orig_rgba.g * (1 - tex.a) + tex.g * tex.a;
-        tex.b = orig_rgba.b * (1 - tex.a) + tex.b * tex.a;
+        tex.r = orig_rgba.r * (1. - tex.a) + tex.r * tex.a;
+        tex.g = orig_rgba.g * (1. - tex.a) + tex.g * tex.a;
+        tex.b = orig_rgba.b * (1. - tex.a) + tex.b * tex.a;
         tex.a = orig_rgba.a;
 
     }

--- a/assets/shaders/ticket_negative.fs
+++ b/assets/shaders/ticket_negative.fs
@@ -117,9 +117,9 @@ vec4 shine_effect( vec4 colour, vec4 tex, vec2 uv, vec2 texture_coords ){
     tex.b = tex.b-delta + delta*maxfac*0.7 - 0.1;
     tex.a = tex.a*(0.5*max(min(1., max(0.,0.3*max(low*0.2, delta)+ min(max(maxfac*0.1,0.), 0.4)) ), 0.) + 0.15*maxfac*(0.1+delta));
 
-    tex.r = orig_rgba.r * (1 - tex.a) + tex.r * tex.a;
-    tex.g = orig_rgba.g * (1 - tex.a) + tex.g * tex.a;
-    tex.b = orig_rgba.b * (1 - tex.a) + tex.b * tex.a;
+    tex.r = orig_rgba.r * (1. - tex.a) + tex.r * tex.a;
+    tex.g = orig_rgba.g * (1. - tex.a) + tex.g * tex.a;
+    tex.b = orig_rgba.b * (1. - tex.a) + tex.b * tex.a;
     tex.a = orig_rgba.a;
 
     return dissolve_mask(tex*colour, texture_coords, uv);
@@ -133,9 +133,9 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
     float omit_top_half = ticket_negative[2];
     float omit_bottom_half = ticket_negative[3];
 
-    if (uv.y <= 0.375 && omit_top_half > 0){
+    if (uv.y <= 0.375 && omit_top_half > 0.){
         tex.a = 0.;
-    } else if (uv.y > 0.375 && omit_bottom_half > 0) {
+    } else if (uv.y > 0.375 && omit_bottom_half > 0.) {
         tex.a = 0.;
     }
 
@@ -162,9 +162,9 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
 	if (tex[3] < 0.7)
 		tex[3] = tex[3]/3.;
 
-    tex.r = orig_rgba.r * (1 - tex.a) + tex.r * tex.a;
-    tex.g = orig_rgba.g * (1 - tex.a) + tex.g * tex.a;
-    tex.b = orig_rgba.b * (1 - tex.a) + tex.b * tex.a;
+    tex.r = orig_rgba.r * (1. - tex.a) + tex.r * tex.a;
+    tex.g = orig_rgba.g * (1. - tex.a) + tex.g * tex.a;
+    tex.b = orig_rgba.b * (1. - tex.a) + tex.b * tex.a;
     tex.a = orig_rgba.a;
 
 	return shine_effect(colour, tex, uv, texture_coords);

--- a/assets/shaders/ticket_polychrome.fs
+++ b/assets/shaders/ticket_polychrome.fs
@@ -102,9 +102,9 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
     float omit_top_half = ticket_polychrome[2];
     float omit_bottom_half = ticket_polychrome[3];
 
-    if (uv.y <= 0.375 && omit_top_half > 0){
+    if (uv.y <= 0.375 && omit_top_half > 0.){
         tex.a = 0.;
-    } else if (uv.y > 0.375 && omit_bottom_half > 0) {
+    } else if (uv.y > 0.375 && omit_bottom_half > 0.) {
         tex.a = 0.;
     }
 
@@ -150,9 +150,9 @@ vec4 effect( vec4 colour, Image texture, vec2 texture_coords, vec2 screen_coords
     if (tex[3] < 0.7)
         tex[3] = tex[3]/3.;
 
-    tex.r = orig_rgba.r * (1 - tex.a) + tex.r * tex.a;
-    tex.g = orig_rgba.g * (1 - tex.a) + tex.g * tex.a;
-    tex.b = orig_rgba.b * (1 - tex.a) + tex.b * tex.a;
+    tex.r = orig_rgba.r * (1. - tex.a) + tex.r * tex.a;
+    tex.g = orig_rgba.g * (1. - tex.a) + tex.g * tex.a;
+    tex.b = orig_rgba.b * (1. - tex.a) + tex.b * tex.a;
     tex.a = orig_rgba.a;
     
 	return dissolve_mask(tex*colour, texture_coords, uv);


### PR DESCRIPTION
Android's strict OpenGL ES shader compiler does not allow implicit type casting between integers and floats.
This causes Balatro to crash on startup with reverie installed on Android devices.
This PR fixes these issues and lets reverie compile its shaders on Android devices while keeping identical behavior on PC.